### PR TITLE
映射文档 No.77

### DIFF
--- a/docs/guides/model_convert/convert_from_pytorch/pytorch_api_mapping_cn.md
+++ b/docs/guides/model_convert/convert_from_pytorch/pytorch_api_mapping_cn.md
@@ -667,6 +667,7 @@
 | 182   |  [torch.Tensor.bitwise_left_shift](https://pytorch.org/docs/stable/generated/torch.Tensor.bitwise_left_shift.html#torch.Tensor.bitwise_left_shift)  |  | 功能缺失        |
 | 183   |  [torch.Tensor.resolve_conj](https://pytorch.org/docs/stable/generated/torch.Tensor.resolve_conj.html#torch.Tensor.resolve_conj)  |  | 功能缺失        |
 | 184   |  [torch.Tensor.resolve_neg](https://pytorch.org/docs/stable/generated/torch.Tensor.resolve_neg.html#torch.Tensor.resolve_neg)  |  | 功能缺失        |
+| 185   |  [torch.Tensor.copysign](https://pytorch.org/docs/1.13/generated/torch.Tensor.copysign.html?highlight=torch+tensor+copysign#torch.Tensor.copysign)  |  | 功能缺失        |
 
 ***持续更新...***
 


### PR DESCRIPTION
77. torch.Tensor.copysign，功能缺失，已标注到 pytorch_api_mapping_cn.md 文件中。

- https://github.com/PaddlePaddle/PaConvert/issues/112